### PR TITLE
PKEntity Deleter Update

### DIFF
--- a/scripts/game/EntityDeleter/PK_EntityDeleter.c
+++ b/scripts/game/EntityDeleter/PK_EntityDeleter.c
@@ -34,7 +34,7 @@ class PK_EntityDeleter : GenericEntity
 
 
 	//------------------------------------------------------------------------------------------------
-	override void EOnInit(IEntity owner)
+	override void EOnActivate(IEntity owner)
 	{
 		QueryEntitiesToRemove = {};
 		// server only


### PR DESCRIPTION
There was an issue where the server and client had mismatched entity tables. The suspected cause was that the deletion logic was being triggered too early during the EonInit event for the server. As a result, when the client connected, its deletion logic did not align with the server’s, leading to extra deletions and a mismatch in the entity tables. This would cause the client to be kicked due to desynchronization.

To address this, the deletion logic was moved from EonInit to EonActivate. This change resolved the issue during peer testing—clients are no longer being kicked, and the entity tables remain in sync.

That said, I’m still unclear whether EonActivate is the most appropriate event for this use case. Some users on the Arma Discord suggested using EonPostFrame, but I wasn’t able to get that working in this context.