### PR TITLE
refactor flags to work as integer counters

### DIFF
--- a/scripts/Game/Components/TILW_ControlModeFlag.c
+++ b/scripts/Game/Components/TILW_ControlModeFlag.c
@@ -4,8 +4,11 @@ class TILW_ControlModeFlagClass : ScriptComponentClass
 }
 class TILW_ControlModeFlag : ScriptComponent
 {
-	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Flag that should be set if the owner AI groups control mode matches the target mode.")]
+	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Flag that should be adjusted if the owner AI groups control mode matches the target mode.")]
 	protected string m_flagName;
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Value that the flag should be adjusted by.")]
+	protected int m_flagValue;
 	
 	[Attribute("2", UIWidgets.ComboBox, "Select target control mode - autonomous = combat movement.\nNote that with some waypoints like defend, individual soliders would engage in combat while the group stays in FOLLOWING_WAYPOINT.", enums: ParamEnumArray.FromEnum(EGroupControlMode))]
 	protected EGroupControlMode m_targetControlMode;
@@ -35,7 +38,16 @@ class TILW_ControlModeFlag : ScriptComponent
 	
 	protected void OnControlModeChanged(EGroupControlMode mode)
 	{
-		TILW_MissionFrameworkEntity.GetInstance().AdjustMissionFlag(m_flagName, mode == m_targetControlMode);
+		int adjustValue = m_flagValue;
+		if (mode != m_targetControlMode)
+			adjustValue = -m_flagValue;
+
+		TILW_MissionFrameworkEntity mfe = TILW_MissionFrameworkEntity.GetInstance();
+		if (mfe)
+		{
+			int newValue = mfe.GetMissionFlag(m_flagName) + adjustValue;
+			mfe.AdjustMissionFlag(m_flagName, newValue);
+		}
 		if (!m_continuous && mode == m_targetControlMode)
 		{
 			SCR_AIGroupInfoComponent groupInfo = SCR_AIGroupInfoComponent.Cast(GetOwner().FindComponent(SCR_AIGroupInfoComponent));

--- a/scripts/Game/Components/TILW_EntityDamageFlag.c
+++ b/scripts/Game/Components/TILW_EntityDamageFlag.c
@@ -4,8 +4,11 @@ class TILW_Flag_EntityDamageClass : ScriptComponentClass
 }
 class TILW_Flag_EntityDamage : ScriptComponent
 {
-	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Flag that should be set if the entities damage state matches the target state / cleared if it doesn't.")]
+	[Attribute(defvalue: "", uiwidget: UIWidgets.Auto, desc: "Flag that should be adjusted if the entities damage state matches the target state / cleared if it doesn't.")]
 	string m_flagName;
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Value that the flag should be adjusted by.")]
+	int m_flagValue;
 	
 	[Attribute("2", UIWidgets.ComboBox, "Select target state for the selected hit zone (destroyed/killed, repaired/healed etc.)", enums: ParamEnumArray.FromEnum(EDamageState))]
 	EDamageState m_targetState;
@@ -18,6 +21,8 @@ class TILW_Flag_EntityDamage : ScriptComponent
 	
 	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "What the initial health of the hit zone should be.", params: "0 1 0.01")]
 	float m_initialHealth;
+	
+	EDamageState m_prevState;
 	
 	void TILW_Flag_EntityDamage(IEntityComponentSource src, IEntity ent, IEntity parent)
 	{
@@ -38,6 +43,17 @@ class TILW_Flag_EntityDamage : ScriptComponent
 		if (!hz)
 			return;
 		
+		m_prevState = hz.GetDamageState();
+		
+		if (m_prevState == m_targetState)
+		{
+			TILW_MissionFrameworkEntity mfe = TILW_MissionFrameworkEntity.GetInstance();
+			int newValue = mfe.GetMissionFlag(m_flagName) + m_flagValue;
+			mfe.AdjustMissionFlag(m_flagName, newValue);
+			if (!m_continuous)
+				return;
+		}
+		
 		hz.GetOnDamageStateChanged().Insert(OnDamageStateChangedHZ);
 		if (m_initialHealth != 1.0)
 			hz.SetHealthScaled(m_initialHealth);
@@ -47,9 +63,21 @@ class TILW_Flag_EntityDamage : ScriptComponent
 	protected void OnDamageStateChangedHZ()
 	{
 		EDamageState newState = GetTargetHitZone().GetDamageState();
-		TILW_MissionFrameworkEntity.GetInstance().AdjustMissionFlag(m_flagName, newState == m_targetState);
-		if (!m_continuous && newState == m_targetState)
-			GetTargetHitZone().GetOnDamageStateChanged().Remove(OnDamageStateChangedHZ);
+		if (newState == m_targetState)
+		{
+			TILW_MissionFrameworkEntity mfe = TILW_MissionFrameworkEntity.GetInstance();
+			int newValue = mfe.GetMissionFlag(m_flagName) + m_flagValue;
+			mfe.AdjustMissionFlag(m_flagName, newValue);
+			if (!m_continuous)
+				GetTargetHitZone().GetOnDamageStateChanged().Remove(OnDamageStateChangedHZ);
+		}
+		else if (m_prevState == m_targetState)
+		{
+			TILW_MissionFrameworkEntity mfe = TILW_MissionFrameworkEntity.GetInstance();
+			int newValue = mfe.GetMissionFlag(m_flagName) - m_flagValue;
+			mfe.AdjustMissionFlag(m_flagName, newValue);
+		}
+		m_prevState = newState;
 	}
 	
 	protected SCR_HitZone GetTargetHitZone()

--- a/scripts/game/Entities/TILW_PrefabSpawnerEntity.c
+++ b/scripts/game/Entities/TILW_PrefabSpawnerEntity.c
@@ -110,7 +110,7 @@ class TILW_PrefabSpawnerEntity : GenericEntity
 			return true;
 		
 		TILW_MissionFrameworkEntity fw = TILW_MissionFrameworkEntity.GetInstance();
-		return (fw && fw.IsMissionFlag(m_conditionFlag));
+		return (fw && fw.GetMissionFlag(m_conditionFlag));
 	}
 	
 	protected void InitSpawn()

--- a/scripts/game/Entities/Triggers/TILW_BaseTriggerEntity.c
+++ b/scripts/game/Entities/Triggers/TILW_BaseTriggerEntity.c
@@ -47,13 +47,16 @@ class TILW_BaseTriggerEntity : GenericEntity
 
 	// EFFECT SETTINGS
 
-	[Attribute("", UIWidgets.Auto, "Set a flag when the condition becomes true (clear it when false)", category: "Trigger Effect")]
+	[Attribute("", UIWidgets.Auto, "Adjust a flag when the condition becomes true (adjust opposite when false)", category: "Trigger Effect")]
 	protected string m_flagName;
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Value that the flag should be adjusted by.", category: "Trigger Effect")]
+	int m_flagValue;
 
 	[Attribute("1", UIWidgets.Auto, "Only invoke SCRIPT events if the gamemode state is GAME (flags are still set, but not checked either way until game start - so mission events are not affected either way).", category: "Trigger Effect")]
 	protected bool m_eventsOnlyDuringGame;
 
-	[Attribute("0", UIWidgets.Auto, "After the effect is first triggered, prevent the trigger from doing any further queries. \nThis also prevents the flag from potentially being cleared again.", category: "Trigger Effect")]
+	[Attribute("0", UIWidgets.Auto, "After the effect is first triggered, prevent the trigger from doing any further queries. \nThis also prevents the flag from potentially being adjusted again.", category: "Trigger Effect")]
 	protected bool m_stopAfterFirstChange;
 
 
@@ -215,10 +218,17 @@ class TILW_BaseTriggerEntity : GenericEntity
 			m_changeProgress = Math.Max(0, m_changeProgress - deltaTime); // Trend back towards 0
 		}
 
-		if (shouldChange || m_firstQuery) {
+		if (shouldChange || (m_firstQuery && condition)) {
+			int adjustValue = m_flagValue;
+			if (!condition)
+				adjustValue = -m_flagValue;
+			
 			TILW_MissionFrameworkEntity mfe = TILW_MissionFrameworkEntity.GetInstance();
 			if (mfe)
-				mfe.AdjustMissionFlag(m_flagName, condition, !m_firstQuery); // Update mission flag
+			{
+				int newValue = mfe.GetMissionFlag(m_flagName) + adjustValue;
+				mfe.AdjustMissionFlag(m_flagName, newValue);
+			}
 			m_lastResult = condition;
 		}
 

--- a/scripts/game/TILW_Instructions.c
+++ b/scripts/game/TILW_Instructions.c
@@ -329,6 +329,8 @@ class TILW_SetFlagInstruction : TILW_BaseInstruction
 {
 	[Attribute("", UIWidgets.Auto, desc: "Name of the flag which should be set.")]
 	protected string m_flagName;
+	[Attribute("1", UIWidgets.Auto, desc: "Value to which the flag should be set.")]
+	protected int m_value;
 	
 	override void Execute()
 	{
@@ -345,6 +347,21 @@ class TILW_ClearFlagInstruction : TILW_BaseInstruction
 	override void Execute()
 	{
 		TILW_MissionFrameworkEntity.GetInstance().AdjustMissionFlag(m_flagName, false);
+	}
+}
+
+[BaseContainerProps(), BaseContainerCustomStringTitleField("Adjust Flag")]
+class TILW_AdjustFlagInstruction : TILW_BaseInstruction
+{
+	[Attribute("", UIWidgets.Auto, desc: "Name of the flag which should be adjusted.")]
+	protected string m_flagName;
+	[Attribute("0", UIWidgets.Auto, desc: "Value which the flag should be incremented or decremented by.")]
+	protected int m_value;
+	
+	override void Execute()
+	{
+		int previousValue = TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_flagName);
+		TILW_MissionFrameworkEntity.GetInstance().AdjustMissionFlag(m_flagName, previousValue + m_value);
 	}
 }
 

--- a/scripts/game/TILW_Instructions.c
+++ b/scripts/game/TILW_Instructions.c
@@ -334,7 +334,7 @@ class TILW_SetFlagInstruction : TILW_BaseInstruction
 	
 	override void Execute()
 	{
-		TILW_MissionFrameworkEntity.GetInstance().AdjustMissionFlag(m_flagName, true);
+		TILW_MissionFrameworkEntity.GetInstance().AdjustMissionFlag(m_flagName, m_value);
 	}
 }
 

--- a/scripts/game/TILW_MissionFrameworkEntity.c
+++ b/scripts/game/TILW_MissionFrameworkEntity.c
@@ -43,9 +43,9 @@ class TILW_MissionFrameworkEntity: GenericEntity
 	
 	// ----- FLAG MANAGEMENT -----------------------------------------------------------------------------------------------------------------------------------------------------------
 	
-	protected ref set<string> m_flagSet = new set<string>();
+	protected ref map<string, int> m_flagSet = new map<string, int>();
 	
-	void AdjustMissionFlag(string name, bool value, bool recheck = true, bool asProxy = false)
+	void AdjustMissionFlag(string name, int value, bool recheck = true, bool asProxy = false)
 	{
 		if (m_rplComp.IsProxy() && !asProxy)
 		{
@@ -53,19 +53,11 @@ class TILW_MissionFrameworkEntity: GenericEntity
 			return;
 		}
 		
-		if (IsMissionFlag(name) == value || name == "")
+		if (GetMissionFlag(name) == value || name == "")
 			return;
-		
-		if (value)
-		{
-			m_flagSet.Insert(name);
-			Print("TILWMF | Set flag: " + name);
-		}
-		else
-		{
-			m_flagSet.RemoveItem(name);
-			Print("TILWMF | Clear flag: " + name);
-		}
+
+		m_flagSet.Set(name, value);
+		Print("TILWMF | Set flag: " + name + ", " + value);
 		
 		if (!m_rplComp.IsProxy())
 		{
@@ -79,9 +71,9 @@ class TILW_MissionFrameworkEntity: GenericEntity
 			m_OnFlagChanged.Invoke(name, true);
 	}
 	
-	bool IsMissionFlag(string name)
+	int GetMissionFlag(string name)
 	{
-		return m_flagSet.Contains(name);
+		return m_flagSet.Get(name);
 	}
 	
 	void RecheckConditions()
@@ -93,10 +85,10 @@ class TILW_MissionFrameworkEntity: GenericEntity
 			missionEvent.EvalExpression();
 	}
 	
-	//! Returns a complete copy of the current flag set. For writing, always use AdjustMissionFlag! For reading individual flags, use IsMissionFlag.
-	set<string> GetFlagSetCopy()
+	//! Returns a complete copy of the current flag set. For writing, always use AdjustMissionFlag! For reading individual flags, use GetMissionFlag.
+	map<string, int> GetFlagSetCopy()
 	{
-		return set<string>.Cast(m_flagSet.Clone());
+		return map<string, int>.Cast(m_flagSet.Clone());
 	}
 	
 	// ----- FLAG REPLICATION -----------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -105,7 +97,7 @@ class TILW_MissionFrameworkEntity: GenericEntity
 	protected RplComponent m_rplComp;
 	
 	[RplRpc(RplChannel.Reliable, RplRcver.Broadcast)]
-	protected void RpcDo_BroadcastFlagChange(string name, bool value, bool recheck)
+	protected void RpcDo_BroadcastFlagChange(string name, int value, bool recheck)
 	{
 		AdjustMissionFlag(name, value, recheck, true);
 	};
@@ -116,7 +108,11 @@ class TILW_MissionFrameworkEntity: GenericEntity
 		writer.Write(flagsCount, 32);
 		
 		for (int i = 0; i < flagsCount; i++)
-			writer.WriteString(m_flagSet[i]);
+		{
+			string key = m_flagSet.GetKey(i);
+			writer.WriteString(key);
+			writer.WriteInt(m_flagSet.Get(key));
+		}
 		
 		return true;
 	}
@@ -130,7 +126,9 @@ class TILW_MissionFrameworkEntity: GenericEntity
 		{
 			string flag;
 			reader.ReadString(flag);
-			AdjustMissionFlag(flag, true, false, true);
+			int value;
+			reader.ReadInt(value);
+			AdjustMissionFlag(flag, value, false, true);
 		}
 		
 		return true;
@@ -486,6 +484,9 @@ class TILW_BaseCasualtyFlag
 {
 	[Attribute("", UIWidgets.Auto, desc: "Flag to be set when the faction reaches the given casualty ratio, or to be cleared when it's below. \nFactionPlayersKilledFlag: Only players are taken into account. \nFactionAIKilledFlag: Only AI is taken into account.")]
 	protected string m_flagName;
+	
+	[Attribute(defvalue: "1", uiwidget: UIWidgets.Auto, desc: "Value that the flag should be adjusted by.")]
+	protected int m_flagValue;
 	
 	[Attribute("", UIWidgets.Auto, desc: "Key of examined faction")]
 	protected string m_factionKey;

--- a/scripts/game/TILW_Terms.c
+++ b/scripts/game/TILW_Terms.c
@@ -156,32 +156,32 @@ class TILW_LiteralTerm : TILW_BaseTerm
 	}
 }
 
-//! TILW_LiteralTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it is greater than specified value
+//! TILW_GreaterTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it is greater than specified value
 [BaseContainerProps(), BaseContainerCustomStringTitleField("Greater Than")]
 class TILW_GreaterTerm : TILW_BaseTerm
 {
 	[Attribute("", UIWidgets.Auto, desc: "Name of the flag (if not found, false)")]
-	protected string m_counterName;
+	protected string m_flagName;
 	[Attribute("1", UIWidgets.Auto, desc: "Exact number the flag has to be greater than", params: "0 inf 1")]
-	protected int m_matchTrue;
+	protected int m_matchGreater;
 	
 	override bool Calc()
 	{
-		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) > m_matchTrue;
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) > m_matchGreater;
 	}
 }
 
-//! TILW_LiteralTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it is less than specified value
+//! TILW_LessTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it is less than specified value
 [BaseContainerProps(), BaseContainerCustomStringTitleField("Less Than")]
 class TILW_LessTerm : TILW_BaseTerm
 {
 	[Attribute("", UIWidgets.Auto, desc: "Name of the flag (if not found, false)")]
-	protected string m_counterName;
+	protected string m_flagName;
 	[Attribute("1", UIWidgets.Auto, desc: "Exact number the flag has to be less than", params: "0 inf 1")]
-	protected int m_matchTrue;
+	protected int m_matchLess;
 	
 	override bool Calc()
 	{
-		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) < m_matchTrue;
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) < m_matchLess;
 	}
 }

--- a/scripts/game/TILW_Terms.c
+++ b/scripts/game/TILW_Terms.c
@@ -138,7 +138,7 @@ class TILW_MatchjunctionTerm : TILW_OperationTerm
 	}
 }
 
-//! TILW_LiteralTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity
+//! TILW_LiteralTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it matches specified value
 [BaseContainerProps(), BaseContainerCustomStringTitleField("Literal (Mission Flag)")]
 class TILW_LiteralTerm : TILW_BaseTerm
 {
@@ -147,11 +147,41 @@ class TILW_LiteralTerm : TILW_BaseTerm
 	
 	override bool Calc()
 	{
-		return TILW_MissionFrameworkEntity.GetInstance().IsMissionFlag(m_flagName);
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_flagName);
 	}
 	
 	void SetFlag(string flagName)
 	{
 		m_flagName = flagName;
+	}
+}
+
+//! TILW_LiteralTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it is greater than specified value
+[BaseContainerProps(), BaseContainerCustomStringTitleField("Greater Than")]
+class TILW_GreaterTerm : TILW_BaseTerm
+{
+	[Attribute("", UIWidgets.Auto, desc: "Name of the flag (if not found, false)")]
+	protected string m_counterName;
+	[Attribute("1", UIWidgets.Auto, desc: "Exact number the flag has to be greater than", params: "0 inf 1")]
+	protected int m_matchTrue;
+	
+	override bool Calc()
+	{
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) > m_matchTrue;
+	}
+}
+
+//! TILW_LiteralTerm gets a value from the TILW_MissionFrameworkEntity, which was previously set by another entity, checks it is less than specified value
+[BaseContainerProps(), BaseContainerCustomStringTitleField("Less Than")]
+class TILW_LessTerm : TILW_BaseTerm
+{
+	[Attribute("", UIWidgets.Auto, desc: "Name of the flag (if not found, false)")]
+	protected string m_counterName;
+	[Attribute("1", UIWidgets.Auto, desc: "Exact number the flag has to be less than", params: "0 inf 1")]
+	protected int m_matchTrue;
+	
+	override bool Calc()
+	{
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) < m_matchTrue;
 	}
 }

--- a/scripts/game/TILW_Terms.c
+++ b/scripts/game/TILW_Terms.c
@@ -167,7 +167,7 @@ class TILW_GreaterTerm : TILW_BaseTerm
 	
 	override bool Calc()
 	{
-		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) > m_matchGreater;
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_flagName) > m_matchGreater;
 	}
 }
 
@@ -182,6 +182,6 @@ class TILW_LessTerm : TILW_BaseTerm
 	
 	override bool Calc()
 	{
-		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_counterName) < m_matchLess;
+		return TILW_MissionFrameworkEntity.GetInstance().GetMissionFlag(m_flagName) < m_matchLess;
 	}
 }

--- a/scripts/game/UserActions/TILW_BaseInteraction.c
+++ b/scripts/game/UserActions/TILW_BaseInteraction.c
@@ -25,7 +25,7 @@ class TILW_BaseInteraction : ScriptedUserAction
 		if (m_conditionFlag == "")
 			return !m_completed;
 		TILW_MissionFrameworkEntity fw = TILW_MissionFrameworkEntity.GetInstance();
-		return (!m_completed && fw && fw.IsMissionFlag(m_conditionFlag));
+		return (!m_completed && fw && fw.GetMissionFlag(m_conditionFlag));
 	}
 
 	//------------------------------------------------------------------------------------------------

--- a/scripts/game/UserActions/TILW_TeleportInteraction.c
+++ b/scripts/game/UserActions/TILW_TeleportInteraction.c
@@ -38,7 +38,7 @@ class TILW_TeleportInteraction : ScriptedUserAction
 			return true;
 
 		TILW_MissionFrameworkEntity fw = TILW_MissionFrameworkEntity.GetInstance();
-		return (fw && fw.IsMissionFlag(m_conditionFlag));
+		return (fw && fw.GetMissionFlag(m_conditionFlag));
 	}
 	//------------------------------------------------------------------------------------------------
 	override bool CanBeShownScript(IEntity user)


### PR DESCRIPTION
I ran away with this a bit so feel free to close if it's not a change you want to see.

- Framework flag list changed from a string set to a map of strings to integers
- Set Flag instruction now sets the flag to the specified value, a default of 1 preserving existing behaviour
- Added Adjust Flag instruction to increment or decrement a flag by the specified value
- Control mode flag, entity damage flag, and base trigger now increment the flag by their specified value when their condition is true and decrement it when it returns to false. These should not do a decrement if the condition is false on first evaluation.
- Added greater and lesser than comparison terms.

Casualty flags left alone as simple 0/1 setters for now, they'd require a bit more work to track their previous condition evaluation.

Enfusion also seems to cleanly handle passing booleans to functions that accept integer parameters, so I expect existing behaviour to be preserved. This change should not affect any existing missions as far as I can tell.

Workbench seems to be producing a bit of unexplainable diff gore, if you view this pull request with ?w=1 as a query string parameter it should display the diff nicer.